### PR TITLE
Add nodiscard attribute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wpedantic \
                                           -Wno-unused")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
+    # earlier versions complain of unused "nodiscard" results in unevaluated contexts
+    # (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89070)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-result")
+  endif()
+
   check_cxx_compiler_flag("-Wnoexcept-type" HAS_NOEXCEPT_TYPE_WARNING)
   if(HAS_NOEXCEPT_TYPE_WARNING)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-noexcept-type")

--- a/catch_tests.cpp
+++ b/catch_tests.cpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -49,7 +50,8 @@ TEST_CASE("Showing that direct constructor is not desirable.")
                                                   with functions is treated
                                                   just like an lvalue... */
 
-  make_scope_guard(inc); // ... but the BEST is really to use the make function
+  std::ignore = make_scope_guard(inc); // ... but the BEST is really to use the
+                                       // make function
 }
 
 /* --- Plain functions, lvalues, rvalues, plain references, consts --- */
@@ -57,7 +59,7 @@ TEST_CASE("Showing that direct constructor is not desirable.")
 ////////////////////////////////////////////////////////////////////////////////
 TEST_CASE("A plain function can be used to create a scope_guard.")
 {
-  make_scope_guard(inc);
+  std::ignore = make_scope_guard(inc);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -103,7 +105,7 @@ TEST_CASE("An lvalue reference to a plain function can be used to create a "
           "scope_guard.")
 {
   auto& inc_ref = inc;
-  make_scope_guard(inc_ref);
+  std::ignore = make_scope_guard(inc_ref);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -153,7 +155,7 @@ TEST_CASE("An lvalue const reference to a plain function can be used to create "
           "a scope_guard.")
 {
   const auto& inc_ref = inc;
-  make_scope_guard(inc_ref);
+  std::ignore = make_scope_guard(inc_ref);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -208,7 +210,7 @@ type, which is treated as lvalue reference. */
 TEST_CASE("An rvalue reference to a plain function can be used to create a "
           "scope_guard.")
 {
-  make_scope_guard(std::move(inc)); // rvalue ref to function treated as lvalue
+  std::ignore = make_scope_guard(std::move(inc)); // rvalue ref to function treated as lvalue
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -257,7 +259,7 @@ TEST_CASE("A dismissed rvalue-reference-to-plain-function-based scope_guard "
 TEST_CASE("A reference wrapper to a plain function can be used to create a "
           "scope_guard.")
 {
-  make_scope_guard(std::ref(inc));
+  std::ignore = make_scope_guard(std::ref(inc));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -302,7 +304,7 @@ TEST_CASE("A dismissed reference-wrapper-to-plain-function-based scope_guard "
 TEST_CASE("A const reference wrapper to a plain function can be used to create "
           "a scope_guard.")
 {
-  make_scope_guard(std::cref(inc));
+  std::ignore = make_scope_guard(std::cref(inc));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -351,7 +353,7 @@ TEST_CASE("An lvalue plain function pointer can be used to create a "
           "scope_guard.")
 {
   const auto fp = &inc;
-  make_scope_guard(fp);
+  std::ignore = make_scope_guard(fp);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -399,7 +401,7 @@ TEST_CASE("A dismissed lvalue-plain-function-pointer-based scope_guard does "
 TEST_CASE("An rvalue plain function pointer can be used to create a "
           "scope_guard.")
 {
-  make_scope_guard(&inc);
+  std::ignore = make_scope_guard(&inc);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -446,7 +448,7 @@ TEST_CASE("An lvalue reference to a plain function pointer can be used to "
 {
   const auto fp = &inc;
   const auto& fp_ref = fp;
-  make_scope_guard(fp_ref);
+  std::ignore = make_scope_guard(fp_ref);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -498,7 +500,7 @@ TEST_CASE("An rvalue reference to a plain function pointer can be used to "
           "create a scope_guard.")
 {
   const auto fp = &inc;
-  make_scope_guard(std::move(fp));
+  std::ignore = make_scope_guard(std::move(fp));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -579,7 +581,7 @@ TEST_CASE("An lvalue std::function that wraps a regular function can be used "
           "to create a scope_guard.")
 {
   const auto stdf = make_std_function(inc);
-  make_scope_guard(stdf);
+  std::ignore = make_scope_guard(stdf);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -629,8 +631,8 @@ TEST_CASE("A dismissed scope_guard that was created with a "
 TEST_CASE("An rvalue std::function that wraps a regular function can be used "
           "to create a scope_guard.")
 {
-  make_scope_guard(make_std_function(inc));
-  make_scope_guard(std::function<void()>{inc});
+  std::ignore = make_scope_guard(make_std_function(inc));
+  std::ignore = make_scope_guard(std::function<void()>{inc});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -680,7 +682,7 @@ TEST_CASE("An lvalue reference to a std::function that wraps a regular "
 {
   const auto stdf = make_std_function(inc);
   const auto& stdf_ref = stdf;
-  make_scope_guard(stdf_ref);
+  std::ignore = make_scope_guard(stdf_ref);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -735,7 +737,7 @@ TEST_CASE("An rvalue reference to a std::function that wraps a regular "
           "function can be used to create a scope_guard.")
 {
   const auto stdf = make_std_function(inc);
-  make_scope_guard(std::move(stdf));
+  std::ignore = make_scope_guard(std::move(stdf));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -795,7 +797,7 @@ namespace
 TEST_CASE("A lambda function with no capture can be used to create a "
           "scope_guard.")
 {
-  make_scope_guard([]()noexcept{});
+  std::ignore = make_scope_guard([]()noexcept{});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -840,7 +842,8 @@ TEST_CASE("A lambda function with capture can be used to create a scope_guard.")
 {
   auto f = 0.0f;
   const auto i = -1;
-  make_scope_guard([&f, i]()noexcept{ f = static_cast<float>(*&i); });
+  std::ignore = make_scope_guard([&f, i]() noexcept
+                                 { f = static_cast<float>(*&i); });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -891,7 +894,7 @@ TEST_CASE("A const lambda function with capture can be used to create a "
   auto f = 0.0f;
   const auto i = -1;
   const auto lambda = [&f, i]() noexcept { f = static_cast<float>(*&i); };
-  make_scope_guard(lambda);
+  std::ignore = make_scope_guard(lambda);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -987,7 +990,7 @@ TEST_CASE("A dismissed scope_guard that was created with a "
 TEST_CASE("A lambda function calling a std::function can be used to create a "
           "scope_guard.")
 {
-  make_scope_guard([]()noexcept{ make_std_function(inc)(); });
+  std::ignore = make_scope_guard([]()noexcept{ make_std_function(inc)(); });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1019,7 +1022,7 @@ TEST_CASE("A scope_guard created with a std::function-calling lambda calls "
 TEST_CASE("A std::function wrapping a lambda function can be used to create a "
           "scope_guard.")
 {
-  make_scope_guard(std::function<void()>([](){}));
+  std::ignore = make_scope_guard(std::function<void()>([](){}));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1042,7 +1045,7 @@ TEST_CASE("A scope_guard created with a lambda-wrapping std::function calls "
 TEST_CASE("A bound function can be used to create a scope_guard.")
 {
   auto boundf_count = 0u;
-  make_scope_guard(std::bind(incc, std::ref(boundf_count)));
+  std::ignore = make_scope_guard(std::bind(incc, std::ref(boundf_count)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1080,7 +1083,7 @@ TEST_CASE("A dismissed bound-function-based scope_guard does not execute its "
 ////////////////////////////////////////////////////////////////////////////////
 TEST_CASE("A bound lambda can be used to create a scope_guard.")
 {
-  make_scope_guard(std::bind([](int /*unused*/){}, 42));
+  std::ignore = make_scope_guard(std::bind([](int /*unused*/){}, 42));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1135,7 +1138,7 @@ namespace
 ////////////////////////////////////////////////////////////////////////////////
 TEST_CASE("A stateless custom functor can be used to create a scope_guard")
 {
-  make_scope_guard(StatelessFunctor{});
+  std::ignore = make_scope_guard(StatelessFunctor{});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1156,7 +1159,7 @@ TEST_CASE("A stateless-custom-functor-based scope_guard calls the functor "
 TEST_CASE("A stateful custom functor can be used to create a scope_guard")
 {
   auto u = 123u;
-  make_scope_guard(StatefulFunctor{u});
+  std::ignore = make_scope_guard(StatefulFunctor{u});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1177,7 +1180,7 @@ TEST_CASE("A stateful-custom-functor-based scope_guard calls the functor "
 TEST_CASE("A const custom functor can be used to create a scope_guard")
 {
   const auto fun = StatelessFunctor{};
-  make_scope_guard(fun);
+  std::ignore = make_scope_guard(fun);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1201,7 +1204,7 @@ TEST_CASE("An lvalue reference to a noncopyable and nonmovable functor can be "
 {
   nocopy_nomove ncnm{};
   const auto& ncnm_ref = ncnm;
-  make_scope_guard(ncnm_ref);
+  std::ignore = make_scope_guard(ncnm_ref);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1248,7 +1251,7 @@ TEST_CASE("An lvalue noncopyable and nonmovable functor can be used to create "
           "a scope_guard, because it binds to an lvalue reference")
 {
   nocopy_nomove ncnm{};
-  make_scope_guard(ncnm);
+  std::ignore = make_scope_guard(ncnm);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1273,7 +1276,7 @@ TEST_CASE("A const lvalue noncopyable and nonmovable functor can be used to "
           "binds to a const lvalue reference")
 {
   const nocopy_nomove ncnm{};
-  make_scope_guard(ncnm);
+  std::ignore = make_scope_guard(ncnm);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1383,7 +1386,7 @@ namespace
 TEST_CASE("A lambda-wrapped regular method can be used to create a scope_guard")
 {
   regular_method_holder h{};
-  make_scope_guard([&h]() noexcept { h.regular_inc_method(); });
+  std::ignore = make_scope_guard([&h]() noexcept { h.regular_inc_method(); });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1423,7 +1426,8 @@ TEST_CASE("A dismissed lambda-wrapped-regular-method-based scope_guard does "
 TEST_CASE("A bound regular method can be used to create a scope_guard")
 {
   regular_method_holder h{};
-  make_scope_guard(std::bind(&regular_method_holder::regular_inc_method, h));
+  std::ignore = make_scope_guard(
+      std::bind(&regular_method_holder::regular_inc_method, h));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1446,7 +1450,7 @@ TEST_CASE("A bound-regular-method-based scope_guard executes the method "
 TEST_CASE("A lambda-wrapped const method can be used to create a scope_guard")
 {
   const const_method_holder h{};
-  make_scope_guard([&h]() noexcept { h.const_inc_method(); });
+  std::ignore = make_scope_guard([&h]() noexcept { h.const_inc_method(); });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1469,7 +1473,8 @@ TEST_CASE("A lambda-wrapped-const-method-based scope_guard executes the "
 TEST_CASE("A bound const method can be used to create a scope_guard")
 {
   const const_method_holder h{};
-  make_scope_guard(std::bind(&const_method_holder::const_inc_method, h));
+  std::ignore =
+      make_scope_guard(std::bind(&const_method_holder::const_inc_method, h));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1509,7 +1514,7 @@ TEST_CASE("A dismissed, bound-const-method-based scope_guard does not execute "
 ////////////////////////////////////////////////////////////////////////////////
 TEST_CASE("A static method can be used to create a scope_guard")
 {
-  make_scope_guard(static_method_holder::static_inc_method);
+  std::ignore = make_scope_guard(static_method_holder::static_inc_method);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1530,7 +1535,7 @@ TEST_CASE("A static-method-based scope_guard executes the static method "
 TEST_CASE("A lambda-wrapped virtual method can be used to create a scope_guard")
 {
   virtual_method_holder h{};
-  make_scope_guard([&h]() noexcept { h.virtual_inc_method(); });
+  std::ignore = make_scope_guard([&h]() noexcept { h.virtual_inc_method(); });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1640,14 +1645,14 @@ namespace
   auto sfinae_tester_impl(T&& t, tag_prefered_overload&& /*ignored*/)
   -> decltype(make_scope_guard(std::forward<T>(t)), std::declval<void>())
   {
-    make_scope_guard(std::forward<T>(t));
+    std::ignore = make_scope_guard(std::forward<T>(t));
   }
 
   template<typename T>
   void sfinae_tester_impl(T&& /*ignored*/,
                           ... /* less specific, so 2nd choice */)
   {
-    make_scope_guard(inc);
+    std::ignore = make_scope_guard(inc);
   }
 
   template<typename T>

--- a/compile_time_tests.cpp
+++ b/compile_time_tests.cpp
@@ -4,9 +4,10 @@
  */
 
 #include "scope_guard.hpp"
-#include <utility>
 #include <functional>
 #include <stdexcept>
+#include <tuple>
+#include <utility>
 
 using namespace sg;
 
@@ -365,17 +366,17 @@ namespace
   {
 #ifdef test_26
     nocopy_nomove ncnm{};
-    make_scope_guard(ncnm);
+    std::ignore = make_scope_guard(ncnm);
 #endif
 #ifdef test_27
     nocopy_nomove ncnm{};
     auto& ncnmr = ncnm;
-    make_scope_guard(ncnmr);
+    std::ignore = make_scope_guard(ncnmr);
 #endif
 #ifdef test_28
     nocopy_nomove ncnm{};
     const auto& ncnmcr = ncnm;
-    make_scope_guard(ncnmcr);
+    std::ignore = make_scope_guard(ncnmcr);
 #endif
   }
 
@@ -404,13 +405,13 @@ namespace
   void test_noexcept_good()
   {
 #ifdef test_32
-    make_scope_guard(non_throwing);
+    std::ignore = make_scope_guard(non_throwing);
 #endif
 #ifdef test_33
-    make_scope_guard(non_throwing_lambda);
+    std::ignore = make_scope_guard(non_throwing_lambda);
 #endif
 #ifdef test_34
-    make_scope_guard(non_throwing_functor);
+    std::ignore = make_scope_guard(non_throwing_functor);
 #endif
   }
 
@@ -424,19 +425,19 @@ namespace
   void test_noexcept_bad()
   {
 #ifdef test_35
-    make_scope_guard(throwing);
+    std::ignore = make_scope_guard(throwing);
 #endif
 #ifdef test_36
-    make_scope_guard(throwing_stdfun);
+    std::ignore = make_scope_guard(throwing_stdfun);
 #endif
 #ifdef test_37
-    make_scope_guard(throwing_lambda);
+    std::ignore = make_scope_guard(throwing_lambda);
 #endif
 #ifdef test_38
-    make_scope_guard(throwing_bound);
+    std::ignore = make_scope_guard(throwing_bound);
 #endif
 #ifdef test_39
-    make_scope_guard(throwing_functor);
+    std::ignore = make_scope_guard(throwing_functor);
 #endif
   }
 
@@ -448,19 +449,19 @@ namespace
   void test_noexcept_fixable()
   {
 #ifdef test_40
-    make_scope_guard(meh);
+    std::ignore = make_scope_guard(meh);
 #endif
 #ifdef test_41
-    make_scope_guard(meh_stdfun);
+    std::ignore = make_scope_guard(meh_stdfun);
 #endif
 #ifdef test_42
-    make_scope_guard(meh_lambda);
+    std::ignore = make_scope_guard(meh_lambda);
 #endif
 #ifdef test_43
-    make_scope_guard(meh_bound);
+    std::ignore = make_scope_guard(meh_bound);
 #endif
 #ifdef test_44
-    make_scope_guard(meh_functor);
+    std::ignore = make_scope_guard(meh_functor);
 #endif
   }
 
@@ -473,10 +474,10 @@ namespace
   void test_noexcept_unfortunate()
   {
 #ifdef test_45
-    make_scope_guard(non_throwing_stdfun);
+    std::ignore = make_scope_guard(non_throwing_stdfun);
 #endif
 #ifdef test_46
-    make_scope_guard(non_throwing_bound);
+    std::ignore = make_scope_guard(non_throwing_bound);
 #endif
   }
 
@@ -510,11 +511,11 @@ namespace
   void test_throwing_dtor_throw_spec_bad()
   {
 #ifdef test_52
-    make_scope_guard(potentially_throwing_dtor{});
+    std::ignore = make_scope_guard(potentially_throwing_dtor{});
 #endif
 #ifdef test_53
     potentially_throwing_dtor x;
-    make_scope_guard(std::move(x));
+    std::ignore = make_scope_guard(std::move(x));
 #endif
   }
 
@@ -559,19 +560,19 @@ namespace
   void test_disallowed_return()
   {
 #ifdef test_57
-    make_scope_guard(returning);
+    std::ignore = make_scope_guard(returning);
 #endif
 #ifdef test_58
-    make_scope_guard(returning_stdfun);
+    std::ignore = make_scope_guard(returning_stdfun);
 #endif
 #ifdef test_59
-    make_scope_guard(returning_lambda);
+    std::ignore = make_scope_guard(returning_lambda);
 #endif
 #ifdef test_60
-    make_scope_guard(returning_bound);
+    std::ignore = make_scope_guard(returning_bound);
 #endif
 #ifdef test_61
-    make_scope_guard(returning_functor);
+    std::ignore = make_scope_guard(returning_functor);
 #endif
   }
 
@@ -582,11 +583,11 @@ namespace
   void test_noncopyable_nonmovable_bad()
   {
 #ifdef test_62
-    make_scope_guard(nocopy_nomove{});
+    std::ignore = make_scope_guard(nocopy_nomove{});
 #endif
 #ifdef test_63
     nocopy_nomove ncnm{};
-    make_scope_guard(std::move(ncnm));
+    std::ignore = make_scope_guard(std::move(ncnm));
 #endif
   }
 

--- a/scope_guard.hpp
+++ b/scope_guard.hpp
@@ -11,8 +11,13 @@
 #include <type_traits>
 #include <utility>
 
-#if __cplusplus >= 201703L && defined(SG_REQUIRE_NOEXCEPT_IN_CPP17)
+#if __cplusplus >= 201703L
+#define SG_NODISCARD [[nodiscard]]
+#ifdef SG_REQUIRE_NOEXCEPT_IN_CPP17
 #define SG_REQUIRE_NOEXCEPT
+#endif
+#else
+#define SG_NODISCARD
 #endif
 
 namespace sg
@@ -93,7 +98,7 @@ namespace sg
     /* --- The template specialization that actually defines the class --- */
 
     template<typename Callback>
-    class scope_guard<Callback> final
+    class SG_NODISCARD scope_guard<Callback> final
     {
     public:
       typedef Callback callback_type;


### PR DESCRIPTION
The `scope_guard` class should be declared `nodiscard` as there really isn't any good reason to discard returned instances of it.