### PR TITLE
[gha] Drop CI on g++-4.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
-            compiler: g++-4.8
-            install: g++-4.8
           - os: ubuntu-20.04
             compiler: g++-7
             install: g++-7


### PR DESCRIPTION
The underlying bionic image is deprecated in GitHub Actions, and the
compiler is getting pretty old anyways.
