### PR TITLE
feat: :sparkles: Allow specifying when to run a scope guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,31 @@ jobs:
           - os: ubuntu-latest
             compiler: g++-11
             install: g++-11
+          - os: ubuntu-latest
+            compiler: g++-14
+            install: g++-14
             extra_build_flags: -DENABLE_COVERAGE:BOOL=ON # coverage build
           - os: ubuntu-20.04
             compiler: clang++-7
             install: clang-7
-          - os: ubuntu-latest
+          - os: ubuntu-21.04
             compiler: clang++-12
-          - os: ubuntu-latest
+            install: clang-12
+          - os: ubuntu-21.04
             compiler: clang++-13
+            install: clang-13
           - os: ubuntu-latest
             compiler: clang++-14
+            install: clang-14
+          - os: ubuntu-latest
+            compiler: clang++-15
+            install: clang-15
+          - os: ubuntu-latest
+            compiler: clang++-16
+            install: clang-16
+          - os: ubuntu-latest
+            compiler: clang++-18
+            install: clang-18
           - os: macos-11
             compiler: g++-10
           - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [ "main" ]

--- a/scope_guard.hpp
+++ b/scope_guard.hpp
@@ -84,22 +84,22 @@ namespace sg
                      std::is_nothrow_destructible<T>>
     {};
 
-    template<ExitType exit_type> class should_run;
-    template<> class should_run<ExitType::ALWAYS> {
+    template<ExitType exit_type> class ShouldRun;
+    template<> class ShouldRun<ExitType::ALWAYS> {
       constexpr static bool should_run() { return true; }
     };
 #if __cplusplus >= 202002L
-    template<> class should_run<ExitType::ON_SUCCESS> {
+    template<> class ShouldRun<ExitType::ON_SUCCESS> {
       static bool should_run() { return std::uncaught_exceptions() == 0; }
     };
-    template<> class should_run<ExitType::ON_FAILURE> {
+    template<> class ShouldRun<ExitType::ON_FAILURE> {
       static bool should_run() { return std::uncaught_exceptions() != 0; }
     };
 #elif __cplusplus >= 201411L
-    template<> class should_run<ExitType::ON_SUCCESS> {
+    template<> class ShouldRun<ExitType::ON_SUCCESS> {
       static bool should_run() { return !std::uncaught_exception(); }
     };
-    template<> class should_run<ExitType::ON_FAILURE> {
+    template<> class ShouldRun<ExitType::ON_FAILURE> {
       static bool should_run() { return std::uncaught_exception(); }
     };
 #endif
@@ -184,7 +184,7 @@ template<typename Callback, sg::ExitType exit_type>
 sg::detail::scope_guard<Callback, exit_type>::scope_guard::~scope_guard() noexcept  /*
 need the extra injected-class-name here to make different compilers happy */
 {
-  if(m_active && should_run<exit_type>::should_run())
+  if(m_active && ShouldRun<exit_type>::should_run())
     m_callback();
 }
 

--- a/scope_guard.hpp
+++ b/scope_guard.hpp
@@ -84,22 +84,22 @@ namespace sg
                      std::is_nothrow_destructible<T>>
     {};
 
-    template<ExitType exit_type> class ShouldRun;
-    template<> class ShouldRun<ExitType::ALWAYS> {
+    template<ExitType exit_type> struct ShouldRun;
+    template<> struct ShouldRun<ExitType::ALWAYS> {
       constexpr static bool should_run() { return true; }
     };
-#if __cplusplus >= 202002L
-    template<> class ShouldRun<ExitType::ON_SUCCESS> {
+#if __cplusplus >= 201703L
+    template<> struct ShouldRun<ExitType::ON_SUCCESS> {
       static bool should_run() { return std::uncaught_exceptions() == 0; }
     };
-    template<> class ShouldRun<ExitType::ON_FAILURE> {
+    template<> struct ShouldRun<ExitType::ON_FAILURE> {
       static bool should_run() { return std::uncaught_exceptions() != 0; }
     };
 #elif __cplusplus >= 201411L
-    template<> class ShouldRun<ExitType::ON_SUCCESS> {
+    template<> struct ShouldRun<ExitType::ON_SUCCESS> {
       static bool should_run() { return !std::uncaught_exception(); }
     };
-    template<> class ShouldRun<ExitType::ON_FAILURE> {
+    template<> struct ShouldRun<ExitType::ON_FAILURE> {
       static bool should_run() { return std::uncaught_exception(); }
     };
 #endif


### PR DESCRIPTION
Allows running a scope guard only when the scope is (or is not) exited due to an exception