### PR TITLE
Update CI and Catch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
 
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 2 # Codecov requests >1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,32 +14,41 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
-            compiler: g++-7
-            install: g++-7
-          - os: ubuntu-latest
+          # GCC on Ubuntu 22.04 (older GCC versions)
+          - os: ubuntu-22.04
             compiler: g++-10
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             compiler: g++-11
-            install: g++-11
-            extra_build_flags: -DENABLE_COVERAGE:BOOL=ON # coverage build
-          - os: ubuntu-20.04
-            compiler: clang++-7
-            install: clang-7
-          - os: ubuntu-latest
-            compiler: clang++-12
-          - os: ubuntu-latest
-            compiler: clang++-13
-          - os: ubuntu-latest
-            compiler: clang++-14
-          - os: macos-11
-            compiler: g++-10
-          - os: macos-latest
+          - os: ubuntu-22.04
             compiler: g++-12
-          - os: macos-latest
-            comp: AppleClang # unused: this is the default compiler and not obvious to specify
-                             # explicitly, but we still want to see the compiler string in the
-                             # GH UI, so use a different var altogether
+          # GCC on Ubuntu 24.04 (newer GCC versions)
+          - os: ubuntu-24.04
+            compiler: g++-13
+          - os: ubuntu-24.04
+            compiler: g++-14
+            extra_build_flags: -DENABLE_COVERAGE:BOOL=ON # coverage build
+          # Clang on Ubuntu 22.04 (older Clang versions)
+          - os: ubuntu-22.04
+            compiler: clang++-13
+          - os: ubuntu-22.04
+            compiler: clang++-14
+          - os: ubuntu-22.04
+            compiler: clang++-15
+          # Clang on Ubuntu 24.04 (newer Clang versions)
+          - os: ubuntu-24.04
+            compiler: clang++-16
+          - os: ubuntu-24.04
+            compiler: clang++-17
+          - os: ubuntu-24.04
+            compiler: clang++-18
+          # GCC on macOS
+          - os: macos-15
+            compiler: g++-13
+          - os: macos-15
+            compiler: g++-15
+          # AppleClang on macOS
+          - os: macos-15
+            comp: AppleClang # default compiler, unused var to show in GH UI
 
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
             compiler: clang++-17
           - os: ubuntu-24.04
             compiler: clang++-18
+          - os: ubuntu-24.04
+            compiler: clang++-19
+            install: clang-19
           # GCC on macOS
           - os: macos-15
             compiler: g++-13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [ "main" ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,10 +93,22 @@ jobs:
                                     # but do run twice as many compilation tests as the number of
                                     # available threads
 
+    - name: Produce coverage reports
+      if: contains(matrix.extra_build_flags, 'coverage')
+      working-directory: ${{github.workspace}}/build
+      run: |
+        echo "Producing coverage reports..."
+        find . -name catch_tests.cpp.gcno -exec gcov -pb {} +
+
+        echo "Finding relevant report..."
+        cov_report=$(find . -name "*scope_guard.hpp.gcov" -exec readlink -e {} +)
+        echo "COV_REPORT=$cov_report" >> $GITHUB_ENV
+
     - name: Codecov
       if: contains(matrix.extra_build_flags, 'coverage')
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        files: ${{ env.COV_REPORT }}
         flags: unittests
         fail_ci_if_error: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
             compiler: g++-13
           - os: ubuntu-24.04
             compiler: g++-14
+            gcov: gcov-14
             extra_build_flags: -DENABLE_COVERAGE:BOOL=ON # coverage build
           # Clang on Ubuntu 22.04 (older Clang versions)
           - os: ubuntu-22.04
@@ -98,7 +99,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         echo "Producing coverage reports..."
-        find . -name catch_tests.cpp.gcno -exec gcov-14 -p {} +
+        find . -name catch_tests.cpp.gcno -exec "${{matrix.gcov}}" -p {} +
 
         echo "Finding relevant report..."
         cov_report=$(find . -name "*scope_guard.hpp.gcov" -exec readlink -e {} +)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,16 +88,10 @@ jobs:
         ARGS=-j$((${num_cpus} * 2)) # don't pass --parallel, which would affect compilation tests,
                                     # but do run twice as many compilation tests as the number of
                                     # available threads
-      
+
     - name: Codecov
       if: contains(matrix.extra_build_flags, 'coverage')
-      working-directory: ${{github.workspace}}/build
-      run: |
-        echo "Producing coverage reports..."
-        find . -name catch_tests.cpp.gcno -exec gcov -pb {} +
-
-        echo "Finding relevant report..."
-        cov_report=$(find . -name "*scope_guard.hpp.gcov" -exec readlink -e {} +)
-
-        echo "The report is ${cov_report}. Uploading to codecov..."
-        bash <(curl -s https://codecov.io/bash) -f $cov_report
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,5 +110,6 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ env.COV_REPORT }}
+        disable_search: true
         flags: unittests
         fail_ci_if_error: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         echo "Producing coverage reports..."
-        find . -name catch_tests.cpp.gcno -exec gcov-14 -pb {} +
+        find . -name catch_tests.cpp.gcno -exec gcov-14 -p {} +
 
         echo "Finding relevant report..."
         cov_report=$(find . -name "*scope_guard.hpp.gcov" -exec readlink -e {} +)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,3 +99,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
+        fail_ci_if_error: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         echo "Producing coverage reports..."
-        find . -name catch_tests.cpp.gcno -exec gcov -pb {} +
+        find . -name catch_tests.cpp.gcno -exec gcov-14 -pb {} +
 
         echo "Finding relevant report..."
         cov_report=$(find . -name "*scope_guard.hpp.gcov" -exec readlink -e {} +)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ Include(FetchContent)
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v2.13.6
+        GIT_TAG        v3.12.0
 )
 
 FetchContent_MakeAvailable(Catch2)
@@ -133,7 +133,7 @@ function(add_catch_tests_batch exe_ret src cxx17 require_noexcept)
   derive_common_test_strings(tst exe ftr # out params
       "catch_batch" TRUE ${cxx17} ${require_noexcept}) # in params
   add_test_exe(${exe} ${src} ${ftr} ${require_noexcept})
-  target_link_libraries(${exe} PRIVATE Catch2::Catch2)
+  target_link_libraries(${exe} PRIVATE Catch2::Catch2WithMain)
 
   add_test(NAME ${tst} COMMAND ${exe} "--order" "lex")
 

--- a/catch_tests.cpp
+++ b/catch_tests.cpp
@@ -5,8 +5,7 @@
 
 #include "scope_guard.hpp"
 
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
-#include "catch2/catch.hpp"
+#include <catch2/catch_test_macros.hpp>
 
 #include <functional>
 #include <list>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  ignore:
+    - "_deps/**"
+    - "build/_deps/**"


### PR DESCRIPTION
Update Linux and macOS CI to work with current GitHub Actions runners. Also update Catch2 to version 3, in order to overcome a CMake deprecation error.

Thank you for taking the initiative in #34 @mosfet80!